### PR TITLE
Fix protobuf 6 compatibility

### DIFF
--- a/wandb/proto/wandb_telemetry_pb2.py
+++ b/wandb/proto/wandb_telemetry_pb2.py
@@ -6,5 +6,8 @@ if protobuf_version == "3":
     from wandb.proto.v3.wandb_telemetry_pb2 import *
 elif protobuf_version == "4":
     from wandb.proto.v4.wandb_telemetry_pb2 import *
-elif protobuf_version == "5":
+else:
+    # Protobuf 5 introduced a new package name which we support via v5
+    # Protocol Buffers 6.x remains backwards compatible with the v5 API,
+    # so fall back to the v5 generated module for any newer versions.
     from wandb.proto.v5.wandb_telemetry_pb2 import *


### PR DESCRIPTION
## Summary
- support protobuf 6 when importing wandb telemetry protos

## Testing
- `pytest tests/unit_tests/test_util.py::test_get_local_path_or_none -q` *(fails: ImportError from wandb/proto/v5/wandb_telemetry_pb2)*

------
https://chatgpt.com/codex/tasks/task_e_683fa843b174832fbdddc9290f477d85